### PR TITLE
store actual password when no pam negotiation has happened

### DIFF
--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -273,9 +273,13 @@ class Session:
         connection = self.irods_session.pool.get_connection()
         pam_passwords = self.irods_session.pam_pw_negotiated
         if len(pam_passwords):
+            actual_password = pam_passwords[0]
+        else:
+            actual_password = self._password
+        if actual_password:
             irods_auth_file = self.irods_session.get_irods_password_file()
             with open(irods_auth_file, "w", encoding="utf-8") as authfd:
-                authfd.write(irods.password_obfuscation.encode(pam_passwords[0]))
+                authfd.write(irods.password_obfuscation.encode(actual_password))
         else:
             warnings.warn("WARNING -- unable to cache obfuscated password locally")
         connection.release()


### PR DESCRIPTION
I believe this fixes the actual cause of the reason that iBridges-for-iRODS/iBridges-GUI#273 was created. (That was not so much the missing authentication scheme, but the fact that a non-pam password needs to be obfuscated)