### PR TITLE
Metadata blacklist

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -85,10 +85,23 @@ Warnings can also be switched off through python's `warnings` package:
 
 .. code-block:: python
 
-   import warnings
-   warnings.filterwarnings("ignore")
+	import warnings
+	warnings.filterwarnings("ignore")ß
+
 
 **My metadata with keys starting with `org_` do not show up in the iBridges metadata.**
 ---------------------------------------------------------------------------------------
 
-iBridges **does not show** metadata that contain a key starting with the prefix `org_`. This is due to data security reasons on `Yoda systems <https://github.com/iBridges-for-iRODS/yoda>`__.
+By default, iBridges **does not show** metadata that contain a key starting with the prefix `org_`. This is due to data security reasons on `Yoda systems <https://github.com/UtrechtUniversity/yoda>`__.
+
+You can omit this by the following code:
+
+.. code-block:: python
+
+    from ibridges.meta import MetaData
+    
+    # collections
+    meta = MetaData(IrodsPath(session, "~", "my_coll").collection, blacklist=None)
+    # data objects
+    meta = MetaData(IrodsPath(session, "~", "my_obj").dataobject, blacklist=None)
+    print(meta)

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -59,11 +59,13 @@ class MetaData:
         if self.blacklist is None:
             yield from self.item.metadata.items()
         for meta in self.item.metadata.items():
-            if re.match(self.blacklist, meta.name) is None:
-                yield meta
-            else:
-                warnings.warn(f"Ignoring metadata entry with value {meta.name}, because it matches "
-                              f"the blacklist {self.blacklist}.")
+            if self.blacklist:
+                if re.match(self.blacklist, meta.name) is None:
+                    yield meta
+                else:
+                    warnings.warn(
+                            f"Ignoring metadata entry with value {meta.name}, because it matches "
+                            f"the blacklist {self.blacklist}.")
 
     def __len__(self) -> int:
         """Get the number of non-blacklisted metadata entries."""
@@ -148,6 +150,9 @@ class MetaData:
         try:
             if (key, value, units) in self:
                 raise ValueError("ADD META: Metadata already present")
+            if self.blacklist:
+                if re.match(self.blacklist, key):
+                    raise ValueError(f"ADD META: Key must not start with {self.blacklist}.")
             self.item.metadata.add(key, value, units)
         except irods.exception.CAT_NO_ACCESS_PERMISSION as error:
             raise PermissionError("UPDATE META: no permissions") from error


### PR DESCRIPTION
To protect the Yoda system metadata which starts with "org_" we introduced a blacklist in the metadata class.

One can omit blacklisting by setting `blacklist = None`. However, there was a little bug, which led to not being able to print the metadata.
I also introduced the checking of the blacklist when a new metadata item is created.