### PR TITLE
bug fix for ipython

### DIFF
--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -61,7 +61,7 @@ def interactive_auth(
     n_tries = 0
     success = False
     while not success and n_tries < 3:
-        if sys.stdin.isatty():
+        if sys.stdin.isatty() or 'ipykernel' in sys.modules:
             password = getpass('Your iRODS password: ')
         else:
             print('Your iRODS password: ')


### PR DESCRIPTION
Previously, there was password prompt and textfield in the jupyter lab when the password needs to be provided.
Now the command shows the prompt 3 times but there is no password field any longer.

It looks like Jupyter lab does not return `True` for `sys.stdin.isatty()` any longer.
The first case in  interactive_auth which uses `getpass` can also be triggered by 

```
if sys.stdin.isatty() or 'ipykernel' in sys.modules
```
Which will open the password prompt in jupyter labs and notebooks.

Tested in jupyter lab, on commandline and in interactive python. I also tested the pipeing of the password to `ibridges init`.
All works.