### PR TITLE
Add basic metadata options to CLI

### DIFF
--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -192,5 +192,5 @@ def test_meta_cli(item_name, request, pass_opts):
     assert ("key", "value", "units") in meta
 
     subprocess.run(["ibridges", "meta-del", cli_path, "--key", "key"], **pass_opts)
-
-    assert len(meta) == 0
+    assert ("key", "value", "units") not in meta
+    #assert len(meta) == 0

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -186,7 +186,7 @@ def test_meta_cli(item_name, request, pass_opts):
     cli_path = f"irods:{item.path}"
 
     ret = subprocess.run(["ibridges", "meta-list", cli_path])
-    assert len(ret.strip("\n")) == 0
+    assert len(ret.stdout.strip("\n")) == 0
 
     subprocess.run(["ibridges", "meta-add", cli_path, "key", "value", "units"])
     assert ("key", "value", "units") in meta

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -186,7 +186,7 @@ def test_meta_cli(item_name, request, pass_opts):
     cli_path = f"irods:{item.path}"
 
     ret = subprocess.run(["ibridges", "meta-list", cli_path], capture_output=True, **pass_opts)
-    assert len(ret.stdout.strip("\n")) == 0
+    assert len(ret.stdout.strip("\n").split("\n")) == 1
 
     subprocess.run(["ibridges", "meta-add", cli_path, "key", "value", "units"], **pass_opts)
     assert ("key", "value", "units") in meta

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -189,10 +189,10 @@ def test_meta_cli(item_name, request, pass_opts):
     assert len(ret.stdout.strip("\n").split("\n")) == 1
 
     subprocess.run(["ibridges", "meta-add", cli_path, "key", "value", "units"], **pass_opts)
-    meta = MetaData(item)
+    meta.refresh()
     assert ("key", "value", "units") in meta
 
     subprocess.run(["ibridges", "meta-del", cli_path, "--key", "key"], **pass_opts)
+    meta.refresh()
     meta = MetaData(item)
     assert ("key", "value", "units") not in meta
-    #assert len(meta) == 0

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -185,12 +185,12 @@ def test_meta_cli(item_name, request, pass_opts):
     meta.clear()
     cli_path = f"irods:{item.path}"
 
-    ret = subprocess.run(["ibridges", "meta-list", cli_path])
+    ret = subprocess.run(["ibridges", "meta-list", cli_path], capture_output=True, **pass_opts)
     assert len(ret.stdout.strip("\n")) == 0
 
-    subprocess.run(["ibridges", "meta-add", cli_path, "key", "value", "units"])
+    subprocess.run(["ibridges", "meta-add", cli_path, "key", "value", "units"], **pass_opts)
     assert ("key", "value", "units") in meta
 
-    subprocess.run(["ibridges", "meta-del", cli_path, "--key", "key"])
+    subprocess.run(["ibridges", "meta-del", cli_path, "--key", "key"], **pass_opts)
 
     assert len(meta) == 0

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -189,8 +189,10 @@ def test_meta_cli(item_name, request, pass_opts):
     assert len(ret.stdout.strip("\n").split("\n")) == 1
 
     subprocess.run(["ibridges", "meta-add", cli_path, "key", "value", "units"], **pass_opts)
+    meta = MetaData(item)
     assert ("key", "value", "units") in meta
 
     subprocess.run(["ibridges", "meta-del", cli_path, "--key", "key"], **pass_opts)
+    meta = MetaData(item)
     assert ("key", "value", "units") not in meta
     #assert len(meta) == 0

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -334,3 +334,4 @@ collection or data object with:
     ibridges meta-del "irods:some_collection"
 
 You will be asked to confirm this operation.
+

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -80,7 +80,7 @@ useful to cache the password so that the next commands will no longer ask for yo
 Listing remote files
 --------------------
 
-To list the dataobjects and collections that are available on the iRODS server, you can use the :code:`ibridges list` command:
+To list the data objects and collections that are available on the iRODS server, you can use the :code:`ibridges list` command:
 
 .. code:: shell
 
@@ -94,9 +94,19 @@ If you want to list a collection relative to your `irods_home`, you can use `~` 
 
     ibridges list "irods:~/collection_in_home"
 
-
 It is generally best to avoid spaces in collection and data object names. If you really need them, you must enclose the path with `"`. That also holds true for local paths.
 
+If you want to have a list that is easier to parse with other command line tools, you can use:
+
+.. code:: shell
+
+    ibridges list --short
+
+You can also see the checksums and sizes of data objects with the long format:
+
+.. code:: shell
+
+    ibridges list --long
 
 .. note::
     Note that all data objects and collections on the iRODS server are always preceded with "irods:". This is done to distinguish local and remote files.
@@ -274,3 +284,53 @@ or
 .. code:: shell
 
     ibridges search --metadata "key" --item_type data_object
+
+
+Metadata commands
+-----------------
+
+Listing metadata
+^^^^^^^^^^^^^^^^
+
+Listing metadata entries for a single collection or data object can be done with the :code:`meta-list`
+subcommand:
+
+.. code:: shell
+
+    ibridges meta-list "irods:some_collection"
+
+Adding new metadata
+^^^^^^^^^^^^^^^^^^^
+
+To add new metadata for a single collection or data object, you can use the :code:`meta-add` subcommand:
+
+.. code:: shell
+
+    ibridges meta-add "irods:some_collection" some_key some_value, some_units
+
+The :code:`some_units` argument can be left out, in which case the units will be set to the empty string.
+
+Deleting metadata
+^^^^^^^^^^^^^^^^^
+
+Metadata can also again be deleted with the CLI using the :code:`meta-del` subcommand:
+
+.. code:: shell
+
+    ibridges meta-del "irods:some_collection" --key some_key --value some_value --units some_units
+
+All of the :code:`--key`, :code:`--value` and :code:`--units` are optional. They serve to constrain
+which metadata items will be deleted. For example, if you only set the key:
+
+.. code:: shell
+
+    ibridges meta-del "irods:some_collection" --key some_key
+
+then **all** metadata items with that key will be deleted. You can delete all metadata for a single
+collection or data object with:
+
+.. code:: shell
+
+    ibridges meta-del "irods:some_collection"
+
+You will be asked to confirm this operation.

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -340,10 +340,32 @@ def ibridges_list():
         help="Show metadata for each iRODS location.",
         action="store_true",
     )
+    parser.add_argument(
+        "-s", "--short",
+        help="Display available data objects/collections in short form.",
+        action="store_true"
+    )
+    parser.add_argument(
+        "-l", "--long",
+        help="Display available data objects/collections in long form.",
+        action="store_true",
+    )
 
     args, _ = parser.parse_known_args()
     with _cli_auth(ienv_path=_get_ienv_path()) as session:
-        _list_coll(session, _parse_remote(args.remote_path, session), args.metadata)
+        ipath =  _parse_remote(args.remote_path, session)
+        if args.long:
+            for cur_path in ipath.walk(depth=1):
+                if str(cur_path) == str(ipath):
+                    continue
+                if cur_path.collection_exists():
+                    print(f"C- {cur_path.name}")
+                else:
+                    print(f"{cur_path.checksum: <50} {cur_path.size: <12} {cur_path.name}")
+        elif args.short:
+            print(" ".join([x.name for x in ipath.walk(depth=1) if str(x) != str(ipath)]))
+        else:
+            _list_coll(session, ipath, args.metadata)
 
 
 def ibridges_meta_show():

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -49,6 +49,12 @@ Available subcommands:
         List the content of a collections, if no path is given, the home collection will be listed.
     tree:
         List a collection and subcollections in a hierarchical way.
+    meta-list:
+        List the metadata of a collection or data object.
+    meta-add:
+        Add a new metadata entry to a collection or data object.
+    meta-del:
+        Delete metadata entries for a collection or data object.
     mkcoll:
         Create the collection and all its parent collections.
     setup:
@@ -68,6 +74,9 @@ ibridges sync ~/directory "irods:~/collection"
 ibridges list irods:~/collection
 ibridges mkcoll irods://~/bli/bla/blubb
 ibridges tree irods:~/collection
+ibridges meta-list irods:~/collection
+ibridges meta-add irods:~/collection key value units
+ibridges meta-del irods:~/collection key value units
 ibridges search --path-pattern "%.txt"
 ibridges search --metadata "key" "value" "units"
 ibridges search --metadata "key" --metadata "key2" "value2"
@@ -120,7 +129,7 @@ def main() -> None:  #pylint: disable=too-many-branches
         ibridges_meta_list()
     elif subcommand == "meta-add":
         ibridges_meta_add()
-    elif subcommand == "meta-del":
+    elif subcommand in ["meta-del", "meta-rm"]:
         ibridges_meta_del()
     else:
         print(f"Invalid subcommand ({subcommand}). For help see ibridges --help")

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -84,7 +84,7 @@ Program information:
 
 
 
-def main() -> None:
+def main() -> None:  #pylint: disable=too-many-branches
     """CLI pointing to different entrypoints."""
     # ensure .irods folder
     irods_loc = Path.home() / ".irods"
@@ -436,7 +436,8 @@ def ibridges_meta_del():
         if args.ignore_blacklist:
             meta.blacklist = None
         if args.key is ... and args.value is ... and args.units is ...:
-            answer = input("This command will delete all metadata for path {ipath}, are you sure? [y/n]")
+            answer = input("This command will delete all metadata for path {ipath},"
+                           " are you sure? [y/n]")
             if answer.lower() != "y":
                 return
         meta.delete(args.key, args.value, args.units)

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -116,8 +116,8 @@ def main() -> None:  #pylint: disable=too-many-branches
         ibridges_setup()
     elif subcommand == "search":
         ibridges_search()
-    elif subcommand in ["meta", "meta-show"]:
-        ibridges_meta_show()
+    elif subcommand in ["meta", "meta-list"]:
+        ibridges_meta_list()
     elif subcommand == "meta-add":
         ibridges_meta_add()
     elif subcommand == "meta-del":
@@ -368,10 +368,10 @@ def ibridges_list():
             _list_coll(session, ipath, args.metadata)
 
 
-def ibridges_meta_show():
+def ibridges_meta_list():
     """List metadata of a a collection on iRODS."""
     parser = argparse.ArgumentParser(
-        prog="ibridges meta-show", description="List a collection on iRODS."
+        prog="ibridges meta-list", description="List a collection on iRODS."
     )
     parser.add_argument(
         "remote_path",

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -262,6 +262,10 @@ class MetaData:
         >>> meta.set("mass", "10", "kg")
 
         """
+        warnings.warn("The 'set' method is deprecated and will be removed in iBridges 2.0. "
+                      f"You can mimick the old behavior with meta.delete('{key}'); "
+                      f"meta.add('{key}', '{value}', '{units}')",
+                      DeprecationWarning, stacklevel=2)
         self.delete(key)
         self.add(key, value, units)
 
@@ -269,7 +273,8 @@ class MetaData:
         self,
         key: str,
         value: Union[None, str] = ...,  # type: ignore
-        units: Union[None, str] = ...,):  # type: ignore
+        units: Union[None, str] = ...,  # type: ignore
+    ):
         """Delete a metadata entry of an item.
 
         Parameters

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -334,6 +334,7 @@ class MetaData:
             If the user has insufficient permissions to delete the metadata.
 
         """
+        self.refresh()
         for meta in self:
             self.item.metadata.remove(meta)
 
@@ -403,6 +404,16 @@ class MetaData:
                 self.add(*meta_tuple)
             except ValueError:
                 pass
+
+    def refresh(self):
+        """Refresh the metadata of the item.
+
+        This is only necessary if the metadata has been modified by another session.
+        """
+        if isinstance(self.item, irods.collection.iRODSCollection):
+            self.item = self.item.manager.sess.collections.get(self.item.path)
+        else:
+            self.item = self.item.manager.sess.data_objects.get(self.item.path)
 
 
 class MetaDataItem:

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -646,6 +646,8 @@ def _get_data_objects(
         Session to get the data objects with.
     coll : irods.collection.iRODSCollection
         The collection to search for all data objects
+    depth:
+        Depth of the data object search, only used for depth==1.
 
     Returns
     -------

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -455,11 +455,12 @@ class IrodsPath:
 
         """
         all_data_objects: dict[str, list[IrodsPath]] = defaultdict(list)
-        for path, name, size, checksum in _get_data_objects(self.session, self.collection):
+        prc_data_objects = _get_data_objects(self.session, self.collection, depth=depth)
+        for path, name, size, checksum in prc_data_objects:
             abs_path = IrodsPath(self.session, path).absolute()
             ipath = CachedIrodsPath(self.session, size, True, checksum, path, name)
             all_data_objects[str(abs_path)].append(ipath)
-        all_collections = _get_subcoll_paths(self.session, self.collection)
+        all_collections = _get_subcoll_paths(self.session, self.collection, depth=depth)
         all_collections = sorted(all_collections, key=str)
         sub_collections: dict[str, list[IrodsPath]] = defaultdict(list)
         for cur_col in all_collections:
@@ -634,7 +635,8 @@ class CachedIrodsPath(IrodsPath):
 
 
 def _get_data_objects(
-    session, coll: irods.collection.iRODSCollection
+    session, coll: irods.collection.iRODSCollection,
+    depth: Optional[int] = None,
 ) -> list[tuple[str, str, int, str]]:
     """Retrieve all data objects in a collection and all its subcollections.
 
@@ -653,6 +655,8 @@ def _get_data_objects(
     """
     # all objects in the collection
     objs = [(obj.collection.path, obj.name, obj.size, obj.checksum) for obj in coll.data_objects]
+    if depth == 1:
+        return objs
 
     # all objects in subcollections
     data_query = session.irods_session.query(
@@ -666,8 +670,13 @@ def _get_data_objects(
     return objs
 
 
-def _get_subcoll_paths(session, coll: irods.collection.iRODSCollection) -> list:
+def _get_subcoll_paths(session, coll: irods.collection.iRODSCollection,
+                       depth: Optional[int] = None) -> list:
     """Retrieve all sub collections in a sub tree starting at coll and returns their IrodsPaths."""
+    if depth == 1:
+        return [CachedIrodsPath(session, None, False, None, subcol.path)
+                for subcol in coll.subcollections]
+
     coll_query = session.irods_session.query(icat.COLL_NAME)
     coll_query = coll_query.filter(icat.LIKE(icat.COLL_NAME, coll.path + "/%"))
 


### PR DESCRIPTION
Adds:

- `ibridges meta-show`: show the metadata for a collection or dataobject.
- `ibridges meta-add`: Add one new metadata entry for a collection or dataobject.
- `ibridges meta-del`: Delete one, multiple or all metadata items using the key/value/units.
- `ibridges list --metadata`: List the collection, including all metadata of the listed items.
- `ibridges list --short`: Mimics Unix `ls` with no options.
- `ibridges list --long`: Shows checksums and sizes of data objects.
- `ibridges ls` alias for `ibridges list`
- `ibridges meta` alias for `ibridges meta-list`

Deprecates:

- `MetaData.set`: I think we should remove this method for 2.0, since the behavior can be easily emulated with two commands (delete/add).

Improvements:

- `IrodsPath.walk`: Performance with depth==1 should be improved for large collections.

TODO:

- [x] Documentation readthedocs
- [x] CLI help
- [x] New tests