### PR TITLE
Workaround PRC different behavior file/dictionary

### DIFF
--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import socket
 import warnings
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Optional, Union
 
 import irods.session
@@ -251,11 +253,25 @@ class Session:
         Internal use only.
         """
         try:
-            irods_session = irods.session.iRODSSession(
-                irods_env_file=self._irods_env_path,
-                application_name=APP_NAME,
-                connection_timeout=self.connection_timeout,
-            )
+            if self._irods_env_path is not None:
+                irods_session = irods.session.iRODSSession(
+                    irods_env_file=self._irods_env_path,
+                    application_name=APP_NAME,
+                    connection_timeout=self.connection_timeout,
+                )
+            else:
+                with NamedTemporaryFile(delete=False, mode="w") as handle:
+                    temp_ienv_path = handle.name
+                    try:
+                        handle.write(json.dumps(self._irods_env))
+                        handle.close()
+                        irods_session = irods.session.iRODSSession(
+                            irods_env_file=temp_ienv_path,
+                            application_name=APP_NAME,
+                            connection_timeout=self.connection_timeout,
+                        )
+                    finally:
+                        os.unlink(temp_ienv_path)
             _ = irods_session.server_version
         except NonAnonymousLoginWithoutPassword as e:
             raise ValueError("No cached password found.") from e

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -260,6 +260,8 @@ class Session:
                     connection_timeout=self.connection_timeout,
                 )
             else:
+                # Create a temporary file for the irods environment dictionary.
+                # From Python 3.12 we could use the delete_on_close parameter.
                 with NamedTemporaryFile(delete=False, mode="w") as handle:
                     temp_ienv_path = handle.name
                     try:
@@ -272,7 +274,7 @@ class Session:
                         )
                     finally:
                         os.unlink(temp_ienv_path)
-            _ = irods_session.server_version
+            _ = irods_session.server_version  # pylint: disable=possibly-used-before-assignment
         except NonAnonymousLoginWithoutPassword as e:
             raise ValueError("No cached password found.") from e
         except Exception as e:


### PR DESCRIPTION
See #299 for the issue. The problem is that the PRC behaves different when supplying the irods environment by file or by arguments. It seems that without the file, the login using the cached password in the `.irodsA` file doesn't work. This is rather a hack by creating a temporary file from the dictionary, any suggestions for improvement are appreciated.

Fixes #299 