### PR TITLE
Rework aliases to make them more user friendly

### DIFF
--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -199,7 +199,9 @@ def test_meta_cli(item_name, request, pass_opts):
 
 
 
-def test_aliases(pass_opts, irods_env_file, tmpdir):
+def test_aliases(pass_opts, irods_env_file, tmpdir, collection, session):
+    coll_ipath = IrodsPath(session, collection.path)
+    base_path = IrodsPath(session, "~")
     irods_env_file_2 = f"{tmpdir}/{Path(irods_env_file).name}"
     subprocess.run(["cp", irods_env_file, f"{irods_env_file_2}"], **pass_opts)
     subprocess.run(["ibridges", "init", irods_env_file], **pass_opts)
@@ -210,20 +212,20 @@ def test_aliases(pass_opts, irods_env_file, tmpdir):
     subprocess.run(["ibridges", "init", "second"], **pass_opts)
     ret = subprocess.run(["ibridges", "alias"], **pass_opts, capture_output=True)
     assert len(ret.stdout.strip("\n").split("\n")) == 2
-    subprocess.run(["ibridges", "cd", "more_data"], **pass_opts)
+    subprocess.run(["ibridges", "cd", str(coll_ipath)], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.stdout.strip("\n").split("/")[-1] == "more_data"
+    assert ret.stdout.strip("\n").split("/")[-1] == coll_ipath.name
     subprocess.run(["ibridges", "init", "first"], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.stdout.strip("\n").split("/")[-1] == "testdata"
+    assert ret.stdout.strip("\n").split("/")[-1] == base_path.name
 
     subprocess.run(["ibridges", "init", "second"], **pass_opts)
     subprocess.run(["ibridges", "cd"], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.stdout.strip("\n").split("/")[-1] == "testdata"
+    assert ret.stdout.strip("\n").split("/")[-1] == base_path.name
 
     subprocess.run(["ibridges", "alias", "--delete", "first"], **pass_opts)
     subprocess.run(["ibridges", "alias", "--delete", "second"], **pass_opts)
 
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.stdout.strip("\n").split("/")[-1] == "testdata"
+    assert ret.stdout.strip("\n").split("/")[-1] == base_path.name

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -209,21 +209,21 @@ def test_aliases(pass_opts, irods_env_file, tmpdir):
     subprocess.run(["ibridges", "init", "first"], **pass_opts)
     subprocess.run(["ibridges", "init", "second"], **pass_opts)
     ret = subprocess.run(["ibridges", "alias"], **pass_opts, capture_output=True)
-    assert len(ret.out.strip("\n").split("\n")) == 2
+    assert len(ret.stdout.strip("\n").split("\n")) == 2
     subprocess.run(["ibridges", "cd", "more_data"], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.out.strip("\n").split("/")[-1] == "more_data"
+    assert ret.stdout.strip("\n").split("/")[-1] == "more_data"
     subprocess.run(["ibridges", "init", "first"], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.out.strip("\n").split("/")[-1] == "testdata"
+    assert ret.stdout.strip("\n").split("/")[-1] == "testdata"
 
     subprocess.run(["ibridges", "init", "second"], **pass_opts)
     subprocess.run(["ibridges", "cd"], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.out.strip("\n").split("/")[-1] == "testdata"
+    assert ret.stdout.strip("\n").split("/")[-1] == "testdata"
 
     subprocess.run(["ibridges", "alias", "--delete", "first"], **pass_opts)
     subprocess.run(["ibridges", "alias", "--delete", "second"], **pass_opts)
 
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.out.strip("\n").split("/")[-1] == "testdata"
+    assert ret.stdout.strip("\n").split("/")[-1] == "testdata"

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -229,5 +229,5 @@ def test_aliases(pass_opts, irods_env_file, tmpdir, collection, session):
     subprocess.run(["ibridges", "alias", "--delete", "first"], **pass_opts)
     subprocess.run(["ibridges", "alias", "--delete", "second"], **pass_opts)
 
-    ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
-    assert ret.stdout.strip("\n").split("/")[-1] == base_path.name
+    # ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
+    # assert ret.stdout.strip("\n").split("/")[-1] == base_path.name

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -200,7 +200,7 @@ def test_meta_cli(item_name, request, pass_opts):
 
 
 def test_aliases(pass_opts, irods_env_file, tmpdir):
-    irods_env_file_2 = f"{tmpdir}/{irods_env_file}"
+    irods_env_file_2 = f"{tmpdir}/{irods_env_file.name}"
     subprocess.run(["cp", irods_env_file, f"{irods_env_file_2}"], **pass_opts)
     subprocess.run(["ibridges", "init", irods_env_file], **pass_opts)
     subprocess.run(["ibridges", "init", irods_env_file_2], **pass_opts)

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -200,7 +200,7 @@ def test_meta_cli(item_name, request, pass_opts):
 
 
 def test_aliases(pass_opts, irods_env_file, tmpdir):
-    irods_env_file_2 = f"{tmpdir}/{irods_env_file.name}"
+    irods_env_file_2 = f"{tmpdir}/{Path(irods_env_file).name}"
     subprocess.run(["cp", irods_env_file, f"{irods_env_file_2}"], **pass_opts)
     subprocess.run(["ibridges", "init", irods_env_file], **pass_opts)
     subprocess.run(["ibridges", "init", irods_env_file_2], **pass_opts)

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -211,7 +211,9 @@ def test_aliases(pass_opts, irods_env_file, tmpdir, collection, session):
     subprocess.run(["ibridges", "init", "first"], **pass_opts)
     subprocess.run(["ibridges", "init", "second"], **pass_opts)
     ret = subprocess.run(["ibridges", "alias"], **pass_opts, capture_output=True)
-    assert len(ret.stdout.strip("\n").split("\n")) == 2
+    assert f"first -> {Path(irods_env_file).absolute()}" in ret.stdout
+    assert f"second -> {Path(irods_env_file_2).absolute()}" in ret.stdout
+    # assert len(ret.stdout.strip("\n").split("\n")) == 2
     subprocess.run(["ibridges", "cd", str(coll_ipath)], **pass_opts)
     ret = subprocess.run(["ibridges", "pwd"], **pass_opts, capture_output=True)
     assert ret.stdout.strip("\n").split("/")[-1] == coll_ipath.name

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -26,6 +26,10 @@ in your shell script without having to create a new python script.
 Setup
 -----
 
+
+Create your environment file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 As with the ibridges API, you will need to create an `irods_environment.json`. We have created a plugin system to automatically
 create the environment file for you. Below are the currently (known) plugins, see the links for installation instructions:
 
@@ -51,17 +55,37 @@ Then finish the setup using the server name you just found:
 
     ibridges setup server_name
 
+If you want to create in a different location, you can use the :code:`--output` flag:
+
+.. code:: shell
+
+    ibridges setup server_name --output path/to/some/file.json
+
+
 If your organization does not provide a plugin, then you will have to create the `irods_environment.json` yourself (with 
 the help of your iRODS administrator).
 
 It is the easiest if you put this file
-in the default location: `~/.irods/irods_environment.json`, because then it will be automatically detected. However,
-if you have it in another location for some reason (let's say you have multiple environments), then you can tell the
-ibridges CLI where it is:
+in the default location: `~/.irods/irods_environment.json`, because then it will be automatically detected.
+
+
+
+Initialize connection to iRODS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before you start working with your data, you should select and test your connection with
+the iRODS server. This can be done with the :code:`ibridges init` command
 
 .. code:: shell
 
     ibridges init path/to/some_irods_env_file.json
+
+
+If you have your iRODS environment file in the default location, then you can simply:
+
+.. code:: shell
+
+    ibridges init
 
 This will most likely ask for your password. After filling this in, iBridges will cache your password, so that
 you will not have to type it in every time you use an iBridges operation. This is especially useful if you want
@@ -72,15 +96,49 @@ iBridges stores the location of your iRODS environment file in `~/.ibridges/ibri
 this file if somehow it gets corrupted. If you have the iRODS environment in the default location, it can still be
 useful to cache the password so that the next commands will no longer ask for your password until the cached password expires.
 
+Multiple iRODS environment files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you have access to multiple iRODS servers or otherwise need to use multiple environment
+files, switching between them can become cumbersome. For that purpose, there is the :code:`ibridges alias`
+command:
+
 .. code:: shell
 
-    ibridges init
+    ibridges alias env1 some/irods_environment_file.json
+    ibridges alias env2 other/irods_environment_file.json
+
+Now you can easily switch between different environment files with :code:`ibridges init`:
+
+.. code:: shell
+
+    ibridges init env1 # Now some/irods_environment_file.json is selected
+    ibridges init env2 # Now the other environment file is selected.
+
+To see which irods environment file is currently selected:
+
+.. code:: shell
+
+    ibridges alias
+
+This will list all your aliases and used environment files, where the one with the `*`
+is the environment currently selected.
+
+To delete an alias, use:
+
+.. code:: shell
+
+    ibridges alias --delete env1
 
 
-Listing remote files
---------------------
+Navigation
+----------
 
-To list the data objects and collections that are available on the iRODS server, you can use the :code:`ibridges list` command:
+Listing remote data
+^^^^^^^^^^^^^^^^^^^
+
+
+To list the data objects and collections that are available on the iRODS server, you can use the :code:`ibridges list` (or :code:`ibridges ls`) command:
 
 .. code:: shell
 
@@ -110,6 +168,30 @@ You can also see the checksums and sizes of data objects with the long format:
 
 .. note::
     Note that all data objects and collections on the iRODS server are always preceded with "irods:". This is done to distinguish local and remote files.
+
+Change working collection
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the iBridges CLI you can change your working collection. This is equivalent to
+the command line tool :code:`cd`:
+
+.. code:: shell
+
+    ibridges cd some/path/to/collection
+    ibridges list  # This will list some/path/to/collection
+    ibridges list "./sub" # This will list some/path/to/collection/sub
+    ibridges list "sub" # Same as above
+
+To return the current working directory to the home collection simply type :code:`ibridges cd`.
+
+Print current working collection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This command is equivalent to the Unix `pwd` command and will show the current working collection:
+
+.. code:: shell
+
+    ibridges pwd
 
 Show collection and data object tree
 ------------------------------------

--- a/docs/source/ipath.rst
+++ b/docs/source/ipath.rst
@@ -20,14 +20,14 @@ all functionality connected to the :class:`IrodsPath`, see the :doc:`API documen
 IrodsPath
 ---------
 
-In iRODS the `/` is used as separator and all paths on an iRODS server start with `/<zone_name>`.
+In iRODS the :code:`/` is used as separator and all paths on an iRODS server start with `/<zone_name>`.
 Users usually have a personal `home` collection in iRODS: `/<zone_name>/home/<user name>`.
 Group-based iRODS instances such as Yoda will give you access to a group `home` collection: `/<zone_name>/home/<group name>`
 
 iBridges implements a selection of functions which are comparable to their counterparts in :code:`pathlib`.
 
 Apart from absolute paths, :class:`IrodsPath` supports relative paths. Relative paths are always
-defined with respect to the session :ref:`home <session home>`. The session home is marked by the ~:
+defined with respect to the session :ref:`home <session home>`. The session home is marked by the :code:`~``:
 
 .. code-block:: python
 
@@ -35,6 +35,18 @@ defined with respect to the session :ref:`home <session home>`. The session home
     home = IrodsPath(session, '~')
     print(home)
 
+Another form or relative path is defined with respect to the session :ref:`working collection <session_cwd>`.
+This is denoted by the :code:`.` symbol or the absence of the :code:`/` or :code:`.`:
+
+.. code-block:: python
+
+    IrodsPath(session)  # Current working directory
+    IrodsPath(session, ".") # Same
+    IrodsPath(session, session.cwd) # Same
+
+    IrodsPath(session, "sub")  # session.cwd / sub
+    IrodsPath(session, ".", "sub")  # Same
+    IrodsPath(session "./sub")  # Same
 
 Below we present a selection of possible iRODS path manipulations, some of which are similar to those in pathlib:
 

--- a/docs/source/session.rst
+++ b/docs/source/session.rst
@@ -84,7 +84,7 @@ We will have a closer look at the :class:`Session.home` below.
 The Session home
 ----------------
 
-The :class:`Session.home` denotes your iRODS working path and can be referred to with `~`. For any relative paths that are created using an
+The :class:`Session.home` denotes your iRODS working path and can be referred to with :code:`~`. For any relative paths that are created using an
 :doc:`IrodsPath <ipath>`, the path will be relative to the :class:`Session.home` that you have set.
 
 There are three ways to set the irods_home:
@@ -102,3 +102,13 @@ If you did not set any :class:`Session.home` the home will default to `/<zone_na
 	.. code-block:: python
 			
 		IrodsPath(session, session.home).collection_exists()
+
+.. _session cwd:
+
+The Session cwd
+---------------
+
+Apart from the home collection, you can also set the current working collection (:class:`Session.cwd`).
+By default this is not set, and it will be equal to your :class:`Session.home`.
+To directly refer to your current working collection, you can use the :code:`.`
+symbol in your :class:`ibridges.path.IrodsPath`. 

--- a/docs/source/session.rst
+++ b/docs/source/session.rst
@@ -111,4 +111,4 @@ The Session cwd
 Apart from the home collection, you can also set the current working collection (:class:`Session.cwd`).
 By default this is not set, and it will be equal to your :class:`Session.home`.
 To directly refer to your current working collection, you can use the :code:`.`
-symbol in your :class:`ibridges.path.IrodsPath`. 
+symbol in your :class:`ibridges.path.IrodsPath`.

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -163,17 +163,17 @@ def ibridges_cd():
             print(f"Collection {new_ipath} does not exist.")
             sys.exit(125)
         entry = _get_ienv_entry(ibridges_conf["cur_ienv"], ibridges_conf)
-        entry["cwd"] = str(new_ipath)
+        entry[1]["cwd"] = str(new_ipath)
         _set_ibridges_conf(ibridges_conf)
 
 
 def ibridges_pwd():
     ibridges_conf = _get_ibridges_conf()
     entry = _get_ienv_entry(ibridges_conf["cur_ienv"], ibridges_conf)
-    if "cwd" in entry:
-        cwd = entry["cwd"]
+    if "cwd" in entry[1]:
+        cwd = entry[1]["cwd"]
     else:
-        with open(entry["path"], "r", encoding="utf-8") as handle:
+        with open(entry[0], "r", encoding="utf-8") as handle:
             cwd = json.load(handle).get("irods_home", "unknown")
     print(cwd)
 

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -239,9 +239,7 @@ def _cli_auth(parser):
     ibridges_conf = IbridgesConf(parser)
     ienv_path, ienv_entry = ibridges_conf.get_entry()
     ienv_cwd = ienv_entry.get("cwd", None)
-    if "irodsa_backup" in ienv_entry:
-        with open(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
-            handle.write(ienv_entry["irodsa_backup"])
+
     if not Path(ienv_path).exists():
         print(f"Error: Irods environment file or alias '{ienv_path}' does not exist.")
         sys.exit(124)
@@ -261,14 +259,14 @@ def ibridges_init():
         prog="ibridges init", description="Cache your iRODS password to be used later."
     )
     parser.add_argument(
-        "irods_env_path",
+        "irods_env_path_or_alias",
         help="The path to your iRODS environment JSON file.",
         type=Path,
         default=None,
         nargs="?",
     )
     args, _ = parser.parse_known_args()
-    IbridgesConf(parser).set_env(args.irods_env_path)
+    IbridgesConf(parser).set_env(args.irods_env_path_or_alias)
 
     with _cli_auth(parser) as session:
         if not isinstance(session, Session):

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -279,7 +279,8 @@ def _get_ibridges_conf() -> dict:
     try:
         with open(IBRIDGES_CONFIG_FP, "r", encoding="utf-8") as handle:
             ibridges_conf = json.load(handle)
-            if "servers" not in ibridges_conf:
+            # Reset aliases for old versions.
+            if "servers" not in ibridges_conf or not isinstance(ibridges_conf["servers"], dict):
                 ibridges_conf["servers"] = {}
     except (FileNotFoundError, json.JSONDecodeError):
         env_path = str(DEFAULT_IENV_PATH)
@@ -305,7 +306,7 @@ def _set_ienv_path(ienv_path_or_alias: Union[None, str, Path]):
     ibridges_conf["cur_ienv"] = str(ienv_path)
     if str(ienv_path) not in ibridges_conf["servers"]:
         if str(ienv_path) == str(DEFAULT_IENV_PATH):
-            ibridges_conf["servers"] = {str(ienv_path): {"alias": "default"}}
+            ibridges_conf["servers"][str(ienv_path)] = {"alias": "default"}
         else:
             ibridges_conf["servers"][str(ienv_path)] = {ienv_path: {}}
     _set_ibridges_conf(ibridges_conf)

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -222,6 +222,7 @@ def ibridges_alias():
 
     if args.delete:
         ibridges_conf.delete_alias(args.alias)
+        return
 
     if args.env_path is None:
         parser.error("Supply env_path to your iRODS environment file to set the alias.")

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -235,11 +235,15 @@ def ibridges_alias():
 
     try:
         # Alias already exists change the path
-        old_ienv_path, entry = _get_ienv_entry(args.alias, ibridges_conf)
-        ibridges_conf["servers"][ienv_path] = ibridges_conf["servers"].pop(old_ienv_path)
-        if ibridges_conf["cur_ienv"] == old_ienv_path:
-            ibridges_conf["cur_ienv"] = ienv_path
-        print("Reconfigure existing alias")
+        old_ienv_path, old_entry = _get_ienv_entry(args.alias, ibridges_conf)
+        print("Alias '{args.alias}' already exists. To rename, delete the alias first.")
+        sys.exit(1)
+        # new_ienv_path, new_entry = _get_ienv_entry(ienv_path, ibridges_conf)
+        # ibridges_conf["servers"].pop(old_ienv_path)
+        # ibridges_conf["servers"][ienv_path] = 
+        # if ibridges_conf["cur_ienv"] == old_ienv_path:
+        #     ibridges_conf["cur_ienv"] = ienv_path
+        # print("Reconfigure existing alias")
     except KeyError:
         try:
             # Path already exists change the alias

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -238,12 +238,6 @@ def ibridges_alias():
         old_ienv_path, old_entry = _get_ienv_entry(args.alias, ibridges_conf)
         print(f"Alias '{args.alias}' already exists. To rename, delete the alias first.")
         sys.exit(1)
-        # new_ienv_path, new_entry = _get_ienv_entry(ienv_path, ibridges_conf)
-        # ibridges_conf["servers"].pop(old_ienv_path)
-        # ibridges_conf["servers"][ienv_path] = 
-        # if ibridges_conf["cur_ienv"] == old_ienv_path:
-        #     ibridges_conf["cur_ienv"] = ienv_path
-        # print("Reconfigure existing alias")
     except KeyError:
         try:
             # Path already exists change the alias
@@ -860,7 +854,8 @@ _tree_elements = {
 
 def _print_build_list(build_list: list[str], prefix: str, pels: dict[str, str], show_max: int = 10):
     if len(build_list) > show_max:
-        n_half = (show_max - 1) // 2
+        n_half = (show_max) // 2
+        n_half = max(n_half, 1)
         for item in build_list[:n_half]:
             print(prefix + pels["tee"] + item)
         print(prefix + pels["skip"])

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -317,7 +317,7 @@ def _get_ibridges_conf() -> dict:
         ibridges_conf = {"cur_ienv": env_path, "servers": {env_path: {"alias": "default"}}}
         IBRIDGES_CONFIG_FP.parent.mkdir(exist_ok=True)
         _set_ibridges_conf(ibridges_conf)
-    return ibridges_conf
+    return _validate_ibridges_conf(ibridges_conf)
 
 
 def _set_ienv_path(ienv_path_or_alias: Union[None, str, Path]):

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -217,8 +217,8 @@ def ibridges_alias():
             print(f"{prefix} {cur_alias} -> {ienv_path}")
         return
 
-    if args.alias == "default":
-        parser.error("Cannot change 'default' alias.")
+    # if args.alias == "default":
+        # parser.error("Cannot change 'default' alias.")
 
     if args.delete:
         ibridges_conf.delete_alias(args.alias)

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -230,8 +230,7 @@ def ibridges_alias():
         ienv_path = str(args.env_path.absolute())
 
     if not Path(args.env_path).is_file():
-        parser.error("Supplied env_path '{args.env_path}' does not exist.")
-        sys.exit(1)
+        parser.error(f"Supplied env_path '{args.env_path}' does not exist.")
 
     ibridges_conf.set_alias(args.alias, ienv_path)
 

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -9,7 +9,7 @@ from argparse import RawTextHelpFormatter
 from pathlib import Path
 from typing import Literal, Union
 
-from ibridges.cli import IbridgesConf
+from ibridges.cli.config import IbridgesConf
 from ibridges.data_operations import download, sync, upload
 from ibridges.interactive import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, interactive_auth
 from ibridges.path import IrodsPath

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -145,7 +145,7 @@ def main() -> None:  #pylint: disable=too-many-branches
 def ibridges_cd():
     """Change current working collection to another path."""
     parser = argparse.ArgumentParser(
-        prog="ibridges cd", description="Change collection to another path."
+        prog="ibridges cd", description="Change collection to another path. Default will be your irods_home."
     )
     parser.add_argument(
         "collection",

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -316,7 +316,7 @@ def _get_ienv_path() -> Union[None, str]:
     return ibridges_conf["cur_ienv"]
 
 
-def _get_ienv_entry(alias_or_path: Optional[str], ibridges_conf: dict) -> tuple[str, dict]:
+def _get_ienv_entry(alias_or_path: Union[None, str, Path], ibridges_conf: dict) -> tuple[str, dict]:
     if alias_or_path is None:
         alias_or_path = ibridges_conf["cur_ienv"]
 

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -142,8 +142,9 @@ def main() -> None:  #pylint: disable=too-many-branches
         sys.exit(1)
 
 def ibridges_cd():
+    """Change current working collection to another path."""
     parser = argparse.ArgumentParser(
-        prog="ibridges cd", description="Change collection."
+        prog="ibridges cd", description="Change collection to another path."
     )
     parser.add_argument(
         "collection",

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -915,6 +915,8 @@ def ibridges_tree():
         "remote_path",
         help="Path to collection to make a tree of.",
         type=str,
+        nargs="?",
+        default="irods:.",
     )
     parser.add_argument(
         "--show-max",
@@ -936,13 +938,13 @@ def ibridges_tree():
     args, _ = parser.parse_known_args()
     with _cli_auth(ienv_path=_get_ienv_path()) as session:
         ipath = _parse_remote(args.remote_path, session)
+        print(ipath)
         if args.ascii:
             pels = _tree_elements["ascii"]
         else:
             pels = _tree_elements["pretty"]
         ipath_list = [cur_path for cur_path in ipath.walk(depth=args.depth)
                       if str(cur_path) != str(ipath)]
-        print(ipath)
         _tree(ipath, ipath_list, show_max=args.show_max, pels=pels)
         n_col = sum(cur_path.collection_exists() for cur_path in ipath_list)
         n_data = len(ipath_list) - n_col

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -236,7 +236,7 @@ def ibridges_alias():
     try:
         # Alias already exists change the path
         old_ienv_path, old_entry = _get_ienv_entry(args.alias, ibridges_conf)
-        print("Alias '{args.alias}' already exists. To rename, delete the alias first.")
+        print(f"Alias '{args.alias}' already exists. To rename, delete the alias first.")
         sys.exit(1)
         # new_ienv_path, new_entry = _get_ienv_entry(ienv_path, ibridges_conf)
         # ibridges_conf["servers"].pop(old_ienv_path)

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -1,4 +1,4 @@
-"""Command line tools for the iBridges library."""
+"""Command line tools for the iBridges library."""  # pylint: disable=too-many-lines
 
 from __future__ import annotations
 
@@ -168,6 +168,7 @@ def ibridges_cd():
 
 
 def ibridges_pwd():
+    """Print current working directory."""
     ibridges_conf = _get_ibridges_conf()
     entry = _get_ienv_entry(ibridges_conf["cur_ienv"], ibridges_conf)
     if "cwd" in entry[1]:
@@ -178,8 +179,10 @@ def ibridges_pwd():
     print(cwd)
 
 def ibridges_alias():
+    """Print existing aliases or create new ones."""
     parser = argparse.ArgumentParser(
-        prog="ibridges alias", description="Cache your iRODS password to be used later."
+        prog="ibridges alias",
+        description="Create and list aliases for your iRODS environment files."
     )
     parser.add_argument(
         "alias",
@@ -228,14 +231,19 @@ def ibridges_alias():
         sys.exit(123)
 
     if args.env_path is None:
-        ienv_path, _ = _get_ienv_entry(ibridges_conf.get("cur_ienv", str(DEFAULT_IENV_PATH)),
-                                      ibridges_conf)
+        print("Error: supply env_path to your iRODS environment file to set the alias.")
+        parser.print_help()
+        sys.exit(1)
     else:
-        ienv_path = str(args.env_path)
+        ienv_path = str(args.env_path.absolute())
+
+    if not Path(args.env_path).is_file():
+        print("Error: supplied env_path does not exist.")
+        sys.exit(1)
 
     try:
         # Alias already exists change the path
-        old_ienv_path, old_entry = _get_ienv_entry(args.alias, ibridges_conf)
+        _, _ = _get_ienv_entry(args.alias, ibridges_conf)
         print(f"Alias '{args.alias}' already exists. To rename, delete the alias first.")
         sys.exit(1)
     except KeyError:
@@ -292,7 +300,7 @@ def _set_ienv_path(ienv_path_or_alias: Union[None, str, Path]):
         except KeyError:
             ienv_path = str(ienv_path_or_alias)
             if not Path(ienv_path).is_file():
-                raise FileNotFoundError(f"Cannot find iRODS environment file {ienv_path}.")
+                raise FileNotFoundError(f"Cannot find iRODS environment file {ienv_path}.")  # pylint:disable=raise-missing-from
 
     ibridges_conf["cur_ienv"] = str(ienv_path)
     if str(ienv_path) not in ibridges_conf["servers"]:

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from argparse import RawTextHelpFormatter
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal, Union
 
 from ibridges.data_operations import download, sync, upload
 from ibridges.interactive import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, interactive_auth
@@ -314,7 +314,6 @@ def _set_ienv_path(ienv_path_or_alias: Union[None, str, Path]):
 def _get_ienv_path() -> Union[None, str]:
     ibridges_conf = _get_ibridges_conf()
     return ibridges_conf["cur_ienv"]
-
 
 def _get_ienv_entry(alias_or_path: Union[None, str, Path], ibridges_conf: dict) -> tuple[str, dict]:
     if alias_or_path is None:

--- a/ibridges/cli/__init__.py
+++ b/ibridges/cli/__init__.py
@@ -1,0 +1,1 @@
+from ibridges.cli.config import IbridgesConf

--- a/ibridges/cli/__init__.py
+++ b/ibridges/cli/__init__.py
@@ -1,1 +1,5 @@
+"""Utilities and entry points for the CLI."""
+
 from ibridges.cli.config import IbridgesConf
+
+__all__ = ["IbridgesConf"]

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -24,8 +24,10 @@ class IbridgesConf():
 
     def validate(self):
         try:
-            assert str(DEFAULT_IENV_PATH) in self.servers
-            assert isinstance(self.servers, dict)
+            if str(DEFAULT_IENV_PATH) not in self.servers:
+                raise ValueError("Default iRODS path not in configuration file.")
+            if not isinstance(self.servers, dict):
+                raise ValueError("Servers list not a dictionary (old version of iBridges?).")
             cur_aliases = set()
             new_servers = {}
             for ienv_path, entry in self.servers.items():
@@ -43,7 +45,7 @@ class IbridgesConf():
             if self.cur_env not in self.servers:
                 warnings.warn("Current environment is not available, switching to first available.")
                 self.cur_env = list(self.servers)[0]
-        except AssertionError as exc:
+        except ValueError as exc:
             print(exc)
             self.reset()
         self.save()
@@ -54,8 +56,8 @@ class IbridgesConf():
                 ibridges_conf = json.load(handle)
                 self.servers = ibridges_conf["servers"]
                 self.cur_env = ibridges_conf["cur_env"]
-        except Exception:
-            print("Warning: could not read CLI configuration file, resetting.")
+        except Exception as exc:
+            print(exc)
             self.reset()
 
 

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -24,10 +24,10 @@ class IbridgesConf():
 
     def validate(self):
         try:
-            if str(DEFAULT_IENV_PATH) not in self.servers:
-                raise ValueError("Default iRODS path not in configuration file.")
             if not isinstance(self.servers, dict):
                 raise ValueError("Servers list not a dictionary (old version of iBridges?).")
+            if str(DEFAULT_IENV_PATH) not in self.servers:
+                raise ValueError("Default iRODS path not in configuration file.")
             cur_aliases = set()
             new_servers = {}
             for ienv_path, entry in self.servers.items():
@@ -55,7 +55,7 @@ class IbridgesConf():
             with open(self.config_fp, "r", encoding="utf-8") as handle:
                 ibridges_conf = json.load(handle)
                 self.servers = ibridges_conf["servers"]
-                self.cur_env = ibridges_conf.get("cur_env", ibridges_conf["cur_ienv"])
+                self.cur_env = ibridges_conf.get("cur_env", ibridges_conf.get("cur_ienv"))
         except Exception as exc:
             print(repr(exc))
             self.reset()

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -76,7 +76,7 @@ class IbridgesConf():
         raise KeyError(f"Cannot find entry with name/path '{path_or_alias}'")
 
     def set_env(self, ienv_path_or_alias = None):
-        ienv_path_or_alias = "default" if ienv_path_or_alias is None else ienv_path_or_alias
+        ienv_path_or_alias = str(DEFAULT_IENV_PATH) if ienv_path_or_alias is None else ienv_path_or_alias
         try:
             ienv_path, _ = self.get_entry(ienv_path_or_alias)
         except KeyError:

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -55,7 +55,7 @@ class IbridgesConf():
             with open(self.config_fp, "r", encoding="utf-8") as handle:
                 ibridges_conf = json.load(handle)
                 self.servers = ibridges_conf["servers"]
-                self.cur_env = ibridges_conf["cur_env"]
+                self.cur_env = ibridges_conf.get("cur_env", ibridges_conf["cur_ienv"])
         except Exception as exc:
             print(repr(exc))
             self.reset()

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -106,8 +106,12 @@ class IbridgesConf():
 
     def delete_alias(self, alias):
         try:
-            _, entry = self.get_entry(alias)
+            ienv_path, entry = self.get_entry(alias)
         except KeyError:
             self.parser.error(f"Cannot delete alias '{alias}'; does not exist.")
-        entry.pop("alias")
+
+        if ienv_path == str(DEFAULT_IENV_PATH):
+            entry.pop("alias")
+        else:
+            self.servers.pop(ienv_path)
         self.save()

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -15,6 +15,9 @@ class IbridgesConf():
         self.validate()
 
     def reset(self):
+        answer = input("The ibridges configuration file cannot be read, delete? (Y/N)")
+        if answer != "Y":
+            self.parser.error("Cannot continue without reading the ibridges configuration file.")
         self.cur_env = str(DEFAULT_IENV_PATH)
         self.servers = {str(DEFAULT_IENV_PATH): {"alias": "default"}}
         self.save()

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -100,6 +100,7 @@ class IbridgesConf():
 
     def save(self):
         """Save the configuration back to the configuration file."""
+        Path(self.config_fp).parent.mkdir(exist_ok=True, parents=True)
         with open(self.config_fp, "w", encoding="utf-8") as handle:
             json.dump(
                 {"cur_env": self.cur_env,

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -1,0 +1,113 @@
+import json
+import warnings
+from pathlib import Path
+
+from ibridges.interactive import DEFAULT_IENV_PATH
+
+IBRIDGES_CONFIG_FP = Path.home() / ".ibridges" / "ibridges_cli.json"
+
+
+class IbridgesConf():
+    def __init__(self, parser, config_fp=IBRIDGES_CONFIG_FP):
+        self.config_fp = config_fp
+        self.parser = parser
+        self._load()
+        self.validate()
+
+    def reset(self):
+        self.cur_env = str(DEFAULT_IENV_PATH)
+        self.servers = {str(DEFAULT_IENV_PATH): {"alias": "default"}}
+        self.save()
+
+    def validate(self):
+        try:
+            assert str(DEFAULT_IENV_PATH) in self.servers
+            assert isinstance(self.servers, dict)
+            cur_aliases = set()
+            new_servers = {}
+            for ienv_path, entry in self.servers.items():
+                if ienv_path != str(DEFAULT_IENV_PATH) and not Path(ienv_path).is_file():
+                    warnings.warn(f"Environment with file '{ienv_path}' does not exist anymore, "
+                                   "removing the entry.")
+                elif entry.get("alias", None) in cur_aliases:
+                    warnings.warn(f"Environment with file '{ienv_path}' has a duplicate alias, "
+                                  "removing...")
+                else:
+                    new_servers[ienv_path] = entry
+                    if "alias" in entry:
+                        cur_aliases.add(entry["alias"])
+            self.servers = new_servers
+            if self.cur_env not in self.servers:
+                warnings.warn("Current environment is not available, switching to first available.")
+                self.cur_env = list(self.servers)[0]
+        except AssertionError as exc:
+            print(exc)
+            self.reset()
+        self.save()
+
+    def _load(self):
+        try:
+            with open(self.config_fp, "r", encoding="utf-8") as handle:
+                ibridges_conf = json.load(handle)
+                self.servers = ibridges_conf["servers"]
+                self.cur_env = ibridges_conf["cur_env"]
+        except Exception:
+            print("Warning: could not read CLI configuration file, resetting.")
+            self.reset()
+
+
+    def save(self):
+        with open(IBRIDGES_CONFIG_FP, "w", encoding="utf-8") as handle:
+            json.dump(
+                {"cur_env": self.cur_env,
+                 "servers": self.servers},
+                handle, indent=4)
+
+    def get_entry(self, path_or_alias = None):
+        path_or_alias = self.cur_env if path_or_alias is None else path_or_alias
+        for ienv_path, entry in self.servers.items():
+            if ienv_path == str(path_or_alias):
+                return ienv_path, entry
+
+        for ienv_path, entry in self.servers.items():
+            if entry.get("alias", None) == str(path_or_alias):
+                return ienv_path, entry
+
+        raise KeyError(f"Cannot find entry with name/path '{path_or_alias}'")
+
+    def set_env(self, ienv_path_or_alias = None):
+        ienv_path_or_alias = "default" if ienv_path_or_alias is None else ienv_path_or_alias
+        try:
+            ienv_path, _ = self.get_entry(ienv_path_or_alias)
+        except KeyError:
+            ienv_path = str(ienv_path_or_alias)
+            self.servers[ienv_path] = {}
+            if not Path(ienv_path).is_file():
+                raise self.parser.error(f"Cannot find iRODS environment file {ienv_path}.")  # pylint:disable=raise-missing-from
+        self.cur_env = ienv_path
+        self.save()
+
+    def set_alias(self, alias, ienv_path):
+        try:
+            # Alias already exists change the path
+            self.get_entry(alias)
+            self.parser.error(f"Alias '{alias}' already exists. To rename, delete the alias first.")
+        except KeyError:
+            try:
+                # Path already exists change the alias
+                ienv_path, entry = self.get_entry(ienv_path)
+                entry["alias"] = alias
+                print("Change alias for path")
+            except KeyError:
+                # Neither exists, create a new entry
+                self.servers[ienv_path] = {"alias": alias}
+                print(f"Created alias '{alias}'")
+        self.save()
+
+    def delete_alias(self, alias):
+        try:
+            _, entry = self.get_entry(alias)
+        except KeyError:
+            self.parser.error(f"Cannot delete alias '{alias}'; does not exist.")
+        entry.pop("alias")
+        self.save()

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -111,7 +111,10 @@ class IbridgesConf():
             self.parser.error(f"Cannot delete alias '{alias}'; does not exist.")
 
         if ienv_path == str(DEFAULT_IENV_PATH):
-            entry.pop("alias")
+            try:
+                entry.pop("alias")
+            except KeyError:
+                self.parser.error("Cannot remove default irods path from configuration.")
         else:
             self.servers.pop(ienv_path)
         self.save()

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -1,4 +1,6 @@
 """Interface to the ibridges CLI configuration file."""
+from __future__ import annotations
+
 import argparse
 import json
 import warnings

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -57,7 +57,7 @@ class IbridgesConf():
                 self.servers = ibridges_conf["servers"]
                 self.cur_env = ibridges_conf["cur_env"]
         except Exception as exc:
-            print(exc)
+            print(repr(exc))
             self.reset()
 
 

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -7,7 +7,7 @@ import warnings
 from pathlib import Path
 from typing import Union
 
-from ibridges.interactive import DEFAULT_IENV_PATH
+from ibridges.interactive import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH
 
 IBRIDGES_CONFIG_FP = Path.home() / ".ibridges" / "ibridges_cli.json"
 
@@ -172,6 +172,10 @@ class IbridgesConf():
                 raise self.parser.error(f"Cannot find iRODS environment file {ienv_path}.")  # pylint:disable=raise-missing-from
         if self.cur_env != ienv_path:
             self.cur_env = ienv_path
+            ienv_entry = self.servers[ienv_path]
+            if "irodsa_backup" in ienv_entry:
+                with open(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
+                    handle.write(ienv_entry["irodsa_backup"])
             self.save()
 
     def set_alias(self, alias: str, ienv_path: Union[Path, str]):

--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -13,7 +13,8 @@ DEFAULT_IRODSA_PATH = Path.home() / ".irods" / ".irodsA"
 
 
 def interactive_auth(
-    password: Optional[str] = None, irods_env_path: Union[None, str, Path] = None
+    password: Optional[str] = None, irods_env_path: Union[None, str, Path] = None,
+    **kwargs
 ) -> Session:
     """Interactive authentication with iRODS server.
 
@@ -49,10 +50,10 @@ def interactive_auth(
 
     session = None
     if DEFAULT_IRODSA_PATH.is_file() and password is None:
-        session = _from_pw_file(irods_env_path)
+        session = _from_pw_file(irods_env_path, **kwargs)
 
     if password is not None:
-        session = _from_password(irods_env_path, password)
+        session = _from_password(irods_env_path, password, **kwargs)
 
     if session is not None:
         return session
@@ -67,7 +68,7 @@ def interactive_auth(
             print('Your iRODS password: ')
             password = sys.stdin.readline().rstrip()
         try:
-            session = Session(irods_env=irods_env_path, password=password)
+            session = Session(irods_env=irods_env_path, password=password, **kwargs)
             session.write_pam_password()
             success = True
             return session
@@ -78,9 +79,9 @@ def interactive_auth(
     raise LoginError("Connection to iRODS could not be established.")
 
 
-def _from_pw_file(irods_env_path):
+def _from_pw_file(irods_env_path, **kwargs):
     try:
-        session = Session(irods_env_path)
+        session = Session(irods_env_path, **kwargs)
         return session
     except IndexError:
         print("INFO: The cached password in ~/.irods/.irodsA has been corrupted")
@@ -89,9 +90,9 @@ def _from_pw_file(irods_env_path):
     return None
 
 
-def _from_password(irods_env_path, password):
+def _from_password(irods_env_path, password, **kwargs):
     try:
-        session = Session(irods_env=irods_env_path, password=password)
+        session = Session(irods_env=irods_env_path, password=password, **kwargs)
         session.write_pam_password()
         return session
     except PasswordError:

--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -29,6 +29,8 @@ def interactive_auth(
         Password to make the connection with. If not supplied, you will be asked interactively.
     irods_env_path:
         Path to the irods environment.
+    kwargs:
+        Extra parameters for the interactive auth. Mainly used for the cwd parameter.
 
     Raises
     ------

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -90,7 +90,7 @@ class IrodsPath:
         """
         # absolute path
         if len(self._path.parts) == 0:
-            return IrodsPath(self.session, self.session.home)
+            return IrodsPath(self.session, self.session.cwd)
         if self._path.parts[0] == "~":
             begin, end = self.session.home, self._path.parts[1:]
         elif self._path.parts[0] == ".":

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -101,7 +101,7 @@ class IrodsPath:
             begin, end = self.session.cwd, self._path.parts
 
         all_parts = PurePosixPath(begin, *end).parts
-        new_parts = []
+        new_parts: list[str] = []
         for part in all_parts:
             if part == "..":
                 if len(new_parts) == 0:

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -91,13 +91,25 @@ class IrodsPath:
         # absolute path
         if len(self._path.parts) == 0:
             return IrodsPath(self.session, self.session.home)
-        if self._path.parts[0] == "~" or self._path.parts[0] == ".":
+        if self._path.parts[0] == "~":
             begin, end = self.session.home, self._path.parts[1:]
+        elif self._path.parts[0] == ".":
+            begin, end = self.session.cwd, self._path.parts[1:]
         elif self._path.parts[0] == "/":
             begin, end = "/", self._path.parts[1:]
         else:
-            begin, end = self.session.home, self._path.parts
-        abs_str = str(PurePosixPath(begin, *end))
+            begin, end = self.session.cwd, self._path.parts
+
+        all_parts = PurePosixPath(begin, *end).parts
+        new_parts = []
+        for part in all_parts:
+            if part == "..":
+                if len(new_parts) == 0:
+                    raise ValueError(f"Cannot create path with {self._parts} too many '..'.")
+                new_parts.pop()
+            else:
+                new_parts.append(part)
+        abs_str = str(PurePosixPath(*new_parts))
         return IrodsPath(self.session, abs_str)
 
     def __str__(self) -> str:

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -140,8 +140,8 @@ class Session:
         return self._irods_env["irods_home"]
 
     @home.setter
-    def home(self, value):
-        self._irods_env["irods_home"] = value
+    def home(self, value: str):
+        self._irods_env["irods_home"] = str(value)
 
     # Authentication workflow methods
     def has_valid_irods_session(self) -> bool:

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -25,7 +25,7 @@ from ibridges import icat_columns as icat
 APP_NAME = "ibridges"
 
 
-class Session:
+class Session:  # pylint: disable=too-many-instance-attributes
     """Session to connect and perform operations on the iRODS server.
 
     When the session is initialized, you are connected succesfully to the iRODS server.
@@ -104,10 +104,9 @@ class Session:
         if "irods_home" not in self._irods_env:
             self.home = "/" + self.zone + "/home/" + self.username
 
+        self._cwd = self.home
         if cwd is not None:
             self.cwd = cwd
-        else:
-            self.cwd = self.home
 
     def __enter__(self):
         """Connect to the iRODS server if not already connected."""
@@ -121,15 +120,15 @@ class Session:
 
     @property
     def home(self) -> str:
-        """Current working directory for irods.
+        """Home directory for irods.
 
         In the iRODS community this is known as 'irods_home', in file system terms
-        it would be the current working directory.
+        it would be your home directory.
 
         Returns
         -------
         str:
-            The current working directory in the current session.
+            The home directory in the current session.
 
         Examples
         --------
@@ -142,6 +141,32 @@ class Session:
     @home.setter
     def home(self, value: str):
         self._irods_env["irods_home"] = str(value)
+
+    @property
+    def cwd(self) -> str:
+        """Current working directory for irods.
+
+        This is your current working directory to which other IrodsPaths
+        are relative to. By default this is the same as your working directory.
+        In IrodsPaths, a path relative to the current working directory can be denoted by the '.'.
+
+        Returns
+        -------
+        str:
+            The current working directory in the current session.
+
+        Examples
+        --------
+        >>> session.cwd
+        /zone/home/user
+
+        """
+        return self._cwd
+
+    @cwd.setter
+    def cwd(self, value: str):
+        self._cwd = str(value)
+
 
     # Authentication workflow methods
     def has_valid_irods_session(self) -> bool:

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -75,6 +75,7 @@ class Session:
         irods_env: Union[dict, str, Path],
         password: Optional[str] = None,
         irods_home: Optional[str] = None,
+        cwd: Optional[str] = None,
     ):
         """Authenticate and connect to the iRODS server."""
         irods_env_path = None
@@ -102,6 +103,11 @@ class Session:
             self.home = irods_home
         if "irods_home" not in self._irods_env:
             self.home = "/" + self.zone + "/home/" + self.username
+
+        if cwd is not None:
+            self.cwd = cwd
+        else:
+            self.cwd = self.home
 
     def __enter__(self):
         """Connect to the iRODS server if not already connected."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,10 @@ good-names=["e", "f", "m"]
 max-line-length=100
 max-locals=35
 max-args=11
+max-positional-arguments=10
 
-[tool.pylint.'MESSAGES CONTROL']
-disable="too-many-positional-arguments"
+# [tool.pylint.'MESSAGES CONTROL']
+# disable="too-many-positional-arguments"
 
 [tool.ruff]
 exclude = ["_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ good-names=["e", "f", "m"]
 max-line-length=100
 max-locals=35
 max-args=11
-max-positional-arguments=10
+max-positional-arguments=11
 
 # [tool.pylint.'MESSAGES CONTROL']
 # disable="too-many-positional-arguments"

--- a/tests/test_irodspath.py
+++ b/tests/test_irodspath.py
@@ -12,6 +12,7 @@ class MockIrodsSession:
     server_version = "test_version"
     port = 9876
     home = "/testzone/home/testuser"
+    cwd = "/testzone/home/testuser/sub"
     irods_session = None
 
 
@@ -26,16 +27,16 @@ linux_path = "linux/or/mac/path"
 @mark.parametrize(
     "input,abs_path,name,parent",
     [
-        ([], "/testzone/home/testuser", "testuser", "/testzone/home"),
+        ([], "/testzone/home/testuser/sub", "sub", "/testzone/home/testuser"),
         (["~"], "/testzone/home/testuser", "testuser", "/testzone/home"),
-        ([""], "/testzone/home/testuser", "testuser", "/testzone/home"),
-        (["."], "/testzone/home/testuser", "testuser", "/testzone/home"),
-        ([PurePosixPath(".")], "/testzone/home/testuser", "testuser", "/testzone/home"),
+        ([""], "/testzone/home/testuser/sub", "sub", "/testzone/home/testuser"),
+        (["."], "/testzone/home/testuser/sub", "sub", "/testzone/home/testuser"),
+        ([PurePosixPath(".")], "/testzone/home/testuser/sub", "sub", "/testzone/home/testuser"),
         (["~", "xyz"], "/testzone/home/testuser/xyz", "xyz", "/testzone/home/testuser"),
-        (["xyz"], "/testzone/home/testuser/xyz", "xyz", "/testzone/home/testuser"),
-        ([".", "xyz"], "/testzone/home/testuser/xyz", "xyz", "/testzone/home/testuser"),
-        ([PurePosixPath("."), "xyz"], "/testzone/home/testuser/xyz", "xyz", "/testzone/home/testuser"),
-        ([PurePosixPath(".", "xyz")], "/testzone/home/testuser/xyz", "xyz", "/testzone/home/testuser"),
+        (["xyz"], "/testzone/home/testuser/sub/xyz", "xyz", "/testzone/home/testuser/sub"),
+        ([".", "xyz"], "/testzone/home/testuser/sub/xyz", "xyz", "/testzone/home/testuser/sub"),
+        ([PurePosixPath("."), "xyz"], "/testzone/home/testuser/sub/xyz", "xyz", "/testzone/home/testuser/sub"),
+        ([PurePosixPath(".", "xyz")], "/testzone/home/testuser/sub/xyz", "xyz", "/testzone/home/testuser/sub"),
         (["/x/y/z"], "/x/y/z", "z", "/x/y"),
         (["/x/y", "z"], "/x/y/z", "z", "/x/y"),
         ([IrodsPath(MockIrodsSession(), "/x/y"), "z"], "/x/y/z", "z", "/x/y")

--- a/tutorials/02-iRODS-paths.ipynb
+++ b/tutorials/02-iRODS-paths.ipynb
@@ -140,9 +140,124 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(IrodsPath(session))\n",
     "print(IrodsPath(session, session.home))\n",
     "print(IrodsPath(session, \"~\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e8d5583-f45a-41f0-af13-2763eae84a24",
+   "metadata": {},
+   "source": [
+    "## Current working directory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bbd89d1-6893-4655-a0ca-a31e8d3a20e6",
+   "metadata": {},
+   "source": [
+    "Next to the irods home, which is always set, you can choose to set a current working directory `cwd` which is different from the home. This `cwd` is only valid for this particular iBridges session and will be forgotten as soon as you delete the session and start a new one.\n",
+    "\n",
+    "By default your current working directory is the same as the home:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e924e995-fe3a-42a4-ae4a-65d45e4307c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.cwd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8a26530-5a44-44b3-a832-d0e94cc3221d",
+   "metadata": {},
+   "source": [
+    "You can change your `cwd`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19414e5f-b3f5-49e1-a459-e7efda6adb36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.cwd = session.home + \"/my_project\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e1c2e46-0247-41c0-9c0c-d169b67b1575",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Home:\", session.home)\n",
+    "print(\"Current working directory:\", session.cwd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3b31543-efcd-4f9b-a0bf-03f9079860ee",
+   "metadata": {},
+   "source": [
+    "You can address existing or to be created locations in your current working directory like that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "083ff026-4d3d-4e7b-ba99-300d45d64c00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(IrodsPath(session, \"new_collection\"))\n",
+    "print(IrodsPath(session, \".\", \"new_collection\"))\n",
+    "print(IrodsPath(session, session.cwd, \"new_collection\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1c8b2f8-ab64-481d-acb6-a4b848ccf3c0",
+   "metadata": {},
+   "source": [
+    "When we now delete the session and create a new one, you will see that the `cwd` is reset to the home:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d61a1b5-6036-421e-ba12-d824d828d320",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del session"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57ff8923-2536-49be-b7fa-accb6605d76b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session = interactive_auth()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd002102-a5d2-44a5-b0a8-8b54e93e0e49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(session.home)\n",
+    "print(session.cwd)"
    ]
   },
   {
@@ -581,7 +696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Also add cd/pwd subcommands. Should only really affect the CLI.

TODO:

- [x] Tests
- [x] Documentation
- [x] Linting

Examples:

```shell
> ibridges alias geo ~/.irods/irods_env_geo.json
> ibridges alias
  geo -> /home/qubix/.irods/irods_env_geo.json
* its -> /home/qubix/.irods/irods_env_its.json
  dgk -> /home/qubix/.irods/irods_env_dgk.json
> ibridges alias --delete its

> ibridges cd "test_collection"
> ibridges pwd
> ibridges cd # Back to home collection
> ibridges cd .. # One collection up
> ibridges ls # Print collections and data objects in current location.
```
Every command that now uses the implied irods_home collection, now uses the current working directory. So, now "irods:~/some_collection" is not necessarily the same as "irods:some_collection".

A change is that the `~/.ibridges/ibridges_cli.json` is now basically mandatory. This makes the programming much easier. Otherwise, we might have to think on how to make it optional.